### PR TITLE
Fixed plugin list delimiter to properly list all plugins

### DIFF
--- a/android/hooks/after_plugin_add/com.ludei.webview.plus.js
+++ b/android/hooks/after_plugin_add/com.ludei.webview.plus.js
@@ -39,7 +39,7 @@ App.prototype = {
 				if(error) throw new Error(stderr);
 				if(this.ctx.CORDOVA_CUSTOM_VERSION >= "3.5.0-0.1.0"){
 					var tmp_list = [];
-					stdout.split("\\n").forEach(function(plugin_info){
+					stdout.split("\n").forEach(function(plugin_info){
 						tmp_list.push(plugin_info.split(" ")[0]);
 					});
 					stdout = JSON.stringify(tmp_list);

--- a/android/hooks/after_plugin_rm/com.ludei.webview.plus.js
+++ b/android/hooks/after_plugin_rm/com.ludei.webview.plus.js
@@ -39,7 +39,7 @@ App.prototype = {
                 if(error) throw new Error(stderr);
                 if(this.ctx.CORDOVA_CUSTOM_VERSION >= "3.5.0-0.1.0"){
                     var tmp_list = [];
-                    stdout.split("\\n").forEach(function(plugin_info){
+                    stdout.split("\n").forEach(function(plugin_info){
                         tmp_list.push(plugin_info.split(" ")[0]);
                     });
                     stdout = JSON.stringify(tmp_list);


### PR DESCRIPTION
Fixed plugin list delimiter to properly list all plugins on processing plugins. Related to issue #36.
